### PR TITLE
Fix example controller and server setup

### DIFF
--- a/src/api/controllers/example.controller.js
+++ b/src/api/controllers/example.controller.js
@@ -1,4 +1,16 @@
+import { GetExampleUseCase } from '../../application/use-cases/getExample.usecase.js';
+
 export const exampleController = (req, res) => {
   const { name, age } = req.body;
   res.status(200).json({ message: `Olá, ${name}! Você tem ${age} anos.` });
+};
+
+export const getExampleController = async (req, res, next) => {
+  try {
+    const useCase = new GetExampleUseCase();
+    const result = await useCase.execute();
+    res.status(200).json(result);
+  } catch (err) {
+    next(err);
+  }
 };

--- a/src/middlewares/correlationId.js
+++ b/src/middlewares/correlationId.js
@@ -1,0 +1,8 @@
+import { randomUUID } from 'crypto';
+
+export const correlationIdMiddleware = (req, res, next) => {
+  const correlationId = req.headers['x-correlation-id'] || randomUUID();
+  req.correlationId = correlationId;
+  res.setHeader('x-correlation-id', correlationId);
+  next();
+};

--- a/src/server.js
+++ b/src/server.js
@@ -12,30 +12,27 @@ import cors from 'cors';
 import compression from 'compression';
 import pinoHttp from 'pino-http';
 import rateLimit from 'express-rate-limit';
+import { traceIdMiddleware } from './middlewares/traceId.js';
+import { metricsMiddleware } from './middlewares/metrics.js';
+import { authenticate } from './middlewares/auth.js';
+import { correlationIdMiddleware } from './middlewares/correlationId.js';
 
 ddTrace.init();
 
 const app = express();
 initConfig();
 
-// Middlewares recomendados
+// Recommended middlewares
 app.use(helmet());
 app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
-import { traceIdMiddleware } from './middlewares/traceId.js';
-import { metricsMiddleware } from './middlewares/metrics.js';
 app.use(traceIdMiddleware);
+app.use(correlationIdMiddleware);
 app.use(metricsMiddleware);
 app.use(pinoHttp({ logger }));
 app.use(compression());
 app.use(rateLimit({ windowMs: 15 * 60 * 1000, max: 100 }));
-
-import { authenticate } from './middlewares/auth.js';
-import { correlationIdMiddleware } from './middlewares/correlationId.js';
-import { metricsMiddleware } from './middlewares/metrics.js';
-app.use(correlationIdMiddleware);
-app.use(metricsMiddleware);
 app.use(authenticate);
 app.use('/api', routes);
 app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));


### PR DESCRIPTION
## Summary
- add correlation ID middleware
- clean up server imports and middleware setup
- implement `getExampleController` to use `GetExampleUseCase`

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846283dd47083308f895db26935debf